### PR TITLE
Fixed stack trace propagation for ChannelExtensions.WaitForTaskOrThrow()

### DIFF
--- a/src/CoCoL/ChannelExtensions.cs
+++ b/src/CoCoL/ChannelExtensions.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using System.Collections.Generic;
+using System.Runtime.ExceptionServices;
 
 namespace CoCoL
 {
@@ -104,7 +105,15 @@ namespace CoCoL
 				throw new TaskCanceledException();
 			else if (task.IsFaulted)
 			{
-                throw task.Exception;
+                var innerExceptions = task.Exception.Flatten().InnerExceptions;
+                if (innerExceptions.Count == 1)
+                {
+                    ExceptionDispatchInfo.Capture(innerExceptions.First()).Throw();
+                }
+                else
+                {
+                    throw task.Exception;
+                }                
 			}
 
 			return task;

--- a/src/CoCoL/ChannelExtensions.cs
+++ b/src/CoCoL/ChannelExtensions.cs
@@ -104,10 +104,7 @@ namespace CoCoL
 				throw new TaskCanceledException();
 			else if (task.IsFaulted)
 			{
-				if (task.Exception.Flatten().InnerExceptions.Count == 1)
-					throw task.Exception.Flatten().InnerExceptions.First();
-				else
-					throw task.Exception;
+                throw task.Exception;
 			}
 
 			return task;

--- a/src/UnitTest/ChannelExtensionsTest.cs
+++ b/src/UnitTest/ChannelExtensionsTest.cs
@@ -1,0 +1,34 @@
+﻿using CoCoL;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace UnitTest
+{
+    [TestFixture]
+    class ChannelExtensionsTest
+    {
+        [Test]
+        public void TestWaitForTaskOrThrow_propagatesStackTrace()
+        {
+            Task t = Task.Factory.StartNew(() => ThrowingMethod());
+
+            try
+            {
+                t.WaitForTaskOrThrow();
+                Assert.Fail("Exception expected!");
+            } catch (Exception ex)
+            {
+                StringAssert.Contains("ThrowingMethod", ex.ToString());
+            }
+        }
+
+        private void ThrowingMethod()
+        {
+            throw new NotImplementedException("This method is not implemented.");
+        }
+    }
+}

--- a/src/UnitTest/UnitTest.csproj
+++ b/src/UnitTest/UnitTest.csproj
@@ -37,6 +37,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ChannelExtensionsTest.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="UntypedTests.cs" />
@@ -95,5 +96,8 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Without stack trace propagation the only hint where to look is the exception message which isn't very helpful for generic errors. If an exception is rethrown directly its stack trace is overwritten by the current stack trace. Wrapping the exception in ExceptionDispatchInfo preserves its original stack trace.