### PR TITLE
Asynchronous cancellation, unit tests, and WriteAsync extension

### DIFF
--- a/src/CoCoL/Channel.cs
+++ b/src/CoCoL/Channel.cs
@@ -165,11 +165,6 @@ namespace CoCoL
 					EnqueueContinuation
 					? TaskCreationOptions.None
 					: TaskCreationOptions.RunContinuationsAsynchronously);
-				if (offer is ICancelAbleOffer cao)
-				{
-					var src = Source; // Lambda functions doesn't capture class variables.
-					cao.CancelToken.Register(() => src.TrySetCanceled());
-				}
 			}
 
 			/// <summary>
@@ -251,11 +246,6 @@ namespace CoCoL
 					EnqueueContinuation
 					? TaskCreationOptions.None
 					: TaskCreationOptions.RunContinuationsAsynchronously);
-				if (offer is ICancelAbleOffer cao)
-				{
-					var src = Source; // Lambda functions doesn't capture class variables.
-					cao.CancelToken.Register(() => src.TrySetCanceled());
-				}
 				Value = value;
 			}
 

--- a/src/CoCoL/Channel.cs
+++ b/src/CoCoL/Channel.cs
@@ -165,6 +165,11 @@ namespace CoCoL
 					EnqueueContinuation
 					? TaskCreationOptions.None
 					: TaskCreationOptions.RunContinuationsAsynchronously);
+				if (offer is ICancelAbleOffer cao)
+				{
+					var src = Source; // Lambda functions doesn't capture class variables.
+					cao.CancelToken.Register(() => src.TrySetCanceled());
+				}
 			}
 
 			/// <summary>
@@ -246,6 +251,11 @@ namespace CoCoL
 					EnqueueContinuation
 					? TaskCreationOptions.None
 					: TaskCreationOptions.RunContinuationsAsynchronously);
+				if (offer is ICancelAbleOffer cao)
+				{
+					var src = Source; // Lambda functions doesn't capture class variables.
+					cao.CancelToken.Register(() => src.TrySetCanceled());
+				}
 				Value = value;
 			}
 

--- a/src/CoCoL/ChannelExtensions.cs
+++ b/src/CoCoL/ChannelExtensions.cs
@@ -942,6 +942,18 @@ namespace CoCoL
 		}
 
 		/// <summary>
+		/// Writes the channel asynchronously with a cancellation token.
+		/// </summary>
+		/// <param name="self">The channel to write.</param>
+		/// <param name="value">The value to write.</param>
+		/// <param name="cancelToken">The cancellation token</param>
+		/// <returns></returns>
+		public static Task WriteAsync(this IUntypedChannel self, object value, CancellationToken cancelToken)
+		{
+			return self.WriteAsync(value, Timeout.Infinite, cancelToken);
+		}
+
+		/// <summary>
 		/// Writes the channel asynchronously
 		/// </summary>
 		/// <returns>The task for awaiting completion.</returns>

--- a/src/CoCoL/ChannelExtensions.cs
+++ b/src/CoCoL/ChannelExtensions.cs
@@ -195,6 +195,7 @@ namespace CoCoL
 		{
 			return TryWriteAsync(self, value, Timeout.Immediate);
 		}
+
 		/// <summary>
 		/// Write to the channel in a probing and asynchronous manner
 		/// </summary>
@@ -207,6 +208,34 @@ namespace CoCoL
 		{
 			return self.WriteAsync(value, new TimeoutOffer(waittime)).ContinueWith(x => x.IsCompleted);
 		}
+
+		/// <summary>
+		/// Write to the channel in a probing and asynchronous manner with a cancellation token
+		/// </summary>
+		/// <param name="self">The channel to read from</param>
+		/// <param name="value">The value to write into the channel</param>
+		/// <param name="cancelToken">The cancellation token</param>
+		/// <typeparam name="T">The channel data type parameter.</typeparam>
+		/// <returns>True if the write succeeded, false otherwise</returns>
+		public static Task<bool> TryWriteAsync<T>(this IWriteChannel<T> self, T value, CancellationToken cancelToken)
+		{
+			return self.WriteAsync(value, new CancellationOffer(cancelToken)).ContinueWith(x => x.IsCompleted && !x.IsFaulted && !x.IsCanceled);
+		}
+
+		/// <summary>
+		/// Write to the channel in a probing and asynchronous manner with a timeout and cancellation token
+		/// </summary>
+		/// <param name="self">The channel to read from</param>
+		/// <param name="value">The value to write into the channel</param>
+		/// <param name="waittime">The time to wait before cancelling</param>
+		/// <param name="cancelToken">The cancellation token</param>
+		/// <typeparam name="T">The channel data type parameter.</typeparam>
+		/// <returns>True if the write succeeded, false otherwise</returns>
+		public static Task<bool> TryWriteAsync<T>(this IWriteChannel<T> self, T value, TimeSpan waittime, CancellationToken cancelToken)
+		{
+			return self.WriteAsync(value, new TimeoutOffer(waittime, cancelToken)).ContinueWith(x => x.IsCompleted && !x.IsFaulted && !x.IsCanceled);
+		}
+
 		/// <summary>
 		/// Reads the channel in a probing and asynchronous manner
 		/// </summary>
@@ -234,6 +263,44 @@ namespace CoCoL
 				return new KeyValuePair<bool, T>(true, x.Result);
 			});
 		}
+
+		/// <summary>
+		/// Tries to read from the channel with a cancellation token.
+		/// </summary>
+		/// <param name="self">The channel to read from</param>
+		/// <param name="cancelToken">The cancellation token</param>
+		/// <typeparam name="T">The channel data type parameter.</typeparam>
+		/// <returns>True if the read succeeded, false otherwise</returns>
+		public static Task<KeyValuePair<bool, T>> TryReadAsync<T>(this IReadChannel<T> self, CancellationToken cancelToken)
+		{
+			return self.ReadAsync(new CancellationOffer(cancelToken)).ContinueWith(x =>
+			{
+				if (x.IsFaulted || x.IsCanceled)
+					return new KeyValuePair<bool, T>(false, default(T));
+
+				return new KeyValuePair<bool, T>(true, x.Result);
+			});
+		}
+
+		/// <summary>
+		/// Tries to read from the channel with a timeout and cancellation token.
+		/// </summary>
+		/// <param name="self">The channel to read from</param>
+		/// <param name="timeout">The read timeout</param>
+		/// <param name="cancelToken">The cancellation token</param>
+		/// <typeparam name="T">The channel data type parameter.</typeparam>
+		/// <returns>True if the read succeeded, false otherwise</returns>
+		public static Task<KeyValuePair<bool, T>> TryReadAsync<T>(this IReadChannel<T> self, TimeSpan timeout, CancellationToken cancelToken)
+		{
+			return self.ReadAsync(new TimeoutOffer(timeout, cancelToken)).ContinueWith(x =>
+			{
+				if (x.IsFaulted || x.IsCanceled)
+					return new KeyValuePair<bool, T>(false, default(T));
+
+				return new KeyValuePair<bool, T>(true, x.Result);
+			});
+		}
+
 		/// <summary>
 		/// Reads the channel asynchronously.
 		/// </summary>

--- a/src/UnitTest/ChannelExtensionsTest.cs
+++ b/src/UnitTest/ChannelExtensionsTest.cs
@@ -27,37 +27,95 @@ namespace UnitTest
         }
 
         [TestMethod]
-        public async Task TestReadCanBeCancelled()
-        {
-            var cts = new System.Threading.CancellationTokenSource();
-            var channel = ChannelManager.CreateChannel<int>(buffersize: 0);
-            var task = channel.ReadAsync(cts.Token);
-            cts.Cancel();
-
-            try
-            {
-                await task;
-                Assert.Fail("Exception expected!");
-            }
-            catch (TaskCanceledException)
-            {
-                // Expected result.
-            }
-        }
-
-        [TestMethod]
-        public async Task TestWriteCanBeCancelled()
+        [DataRow(false, false, false)]
+        [DataRow(false, false, true)]
+        [DataRow(false, true, false)]
+        [DataRow(false, true, true)]
+        [DataRow(true, false, false)]
+        [DataRow(true, false, true)]
+        [DataRow(true, true, false)]
+        [DataRow(true, true, true)]
+        public async Task TestCanBeCancelled(bool use_read, bool use_try, bool use_timeout)
         {
             var cts = new System.Threading.CancellationTokenSource();
             var channel = ChannelManager.CreateChannel<int>(buffersize: 0);
 
-            var task = channel.WriteAsync(1, cts.Token);
+            Task task;
+            if (use_read)
+            {
+                if (use_try)
+                {
+                    if (use_timeout)
+                    {
+                        task = channel.TryReadAsync(TimeSpan.FromSeconds(1), cts.Token);
+                    }
+                    else // !use_timeout
+                    {
+                        task = channel.TryReadAsync(cts.Token);
+                    }
+                }
+                else // !use_try
+                {
+                    if (use_timeout)
+                    {
+                        task = channel.ReadAsync(TimeSpan.FromSeconds(1), cts.Token);
+                    }
+                    else // !use_timeout
+                    {
+                        task = channel.ReadAsync(cts.Token);
+                    }
+                }
+            }
+            else // !use_read
+            {
+                if (use_try)
+                {
+                    if (use_timeout)
+                    {
+                        task = channel.TryWriteAsync(1, TimeSpan.FromSeconds(1), cts.Token);
+                    }
+                    else // !use_timeout
+                    {
+                        task = channel.TryWriteAsync(1, cts.Token);
+                    }
+                }
+                else // !use_try
+                {
+                    if (use_timeout)
+                    {
+                        task = channel.WriteAsync(1, TimeSpan.FromSeconds(1), cts.Token);
+                    }
+                    else // !use_timeout
+                    {
+                        task = channel.WriteAsync(1, cts.Token);
+                    }
+                }
+            }
+
             cts.Cancel();
 
             try
             {
-                await task;
-                Assert.Fail("Exception expected!");
+                if (use_try)
+                {
+                    if (use_read)
+                    {
+                        var bt = task as Task<System.Collections.Generic.KeyValuePair<bool, int>>;
+                        var ret = await bt;
+                        Assert.IsFalse(ret.Key, $"Expected false result for Try operation: {use_read}, {use_try}, {use_timeout}");
+                    }
+                    else
+                    {
+                        var bt = task as Task<bool>;
+                        var ret = await bt;
+                        Assert.IsFalse(ret, $"Expected false result for Try operation: {use_read}, {use_try}, {use_timeout}");
+                    }
+                }
+                else
+                {
+                    await task;
+                    Assert.Fail($"Expected TaskCanceledException: {use_read}, {use_try}, {use_timeout}");
+                }
             }
             catch (TaskCanceledException)
             {

--- a/src/UnitTest/ChannelExtensionsTest.cs
+++ b/src/UnitTest/ChannelExtensionsTest.cs
@@ -26,6 +26,45 @@ namespace UnitTest
             }
         }
 
+        [TestMethod]
+        public async Task TestReadCanBeCancelled()
+        {
+            var cts = new System.Threading.CancellationTokenSource();
+            var channel = ChannelManager.CreateChannel<int>(buffersize: 0);
+            var task = channel.ReadAsync(cts.Token);
+            cts.Cancel();
+
+            try
+            {
+                await task;
+                Assert.Fail("Exception expected!");
+            }
+            catch (TaskCanceledException)
+            {
+                // Expected result.
+            }
+        }
+
+        [TestMethod]
+        public async Task TestWriteCanBeCancelled()
+        {
+            var cts = new System.Threading.CancellationTokenSource();
+            var channel = ChannelManager.CreateChannel<int>(buffersize: 0);
+
+            var task = channel.WriteAsync(1, cts.Token);
+            cts.Cancel();
+
+            try
+            {
+                await task;
+                Assert.Fail("Exception expected!");
+            }
+            catch (TaskCanceledException)
+            {
+                // Expected result.
+            }
+        }
+
         private void ThrowingMethod()
         {
             throw new NotImplementedException("This method is not implemented.");


### PR DESCRIPTION
This PR:
1. ~Registers the `Task` for an asynchronous read (`ReadAsync`) or write (`WriteAsync`) call to the `CancellationToken` that is associated with the offer, if one exists. This allows for cancelling the request through the given token.~ Handled in #20 instead.
2. Adds a unit test for testing whether a blocking calls to channels can be cancelled with the provided `CancellationToken`. 
3. Adds a unit test for testing the normal behaviour of the extension methods. 
4. Adds convenience overloads of `WriteAsync`, `TryWriteAsync`, and `TryReadAsync` for various combinations of with or without `TimeSpan` and `CancellationToken` as parameters.