### PR TITLE
Bugfix/handle unobserved exceptions

### DIFF
--- a/src/CoCoL/ChannelExtensions.cs
+++ b/src/CoCoL/ChannelExtensions.cs
@@ -206,7 +206,24 @@ namespace CoCoL
 		/// <returns>True if the write succeeded, false otherwise</returns>
 		public static Task<bool> TryWriteAsync<T>(this IWriteChannel<T> self, T value, TimeSpan waittime)
 		{
-			return self.WriteAsync(value, new TimeoutOffer(waittime)).ContinueWith(x => x.IsCompleted);
+			return self.WriteAsync(value, new TimeoutOffer(waittime)).ContinueWith(x =>
+			{
+				if (x.IsFaulted || x.IsCanceled)
+				{
+					Exception ex = x.Exception;
+					if (ex is AggregateException aex && aex.InnerExceptions.Count == 1)
+						ex = aex.InnerExceptions[0];
+
+					return ex switch
+					{
+						// Consume timeout exceptions
+						TimeoutException _ => false,
+						_ => throw ex,
+					};
+				}
+
+				return x.IsCompleted;
+			});
 		}
 
 		/// <summary>
@@ -258,7 +275,18 @@ namespace CoCoL
 			return self.ReadAsync(new TimeoutOffer(waittime)).ContinueWith(x =>
 			{
 				if (x.IsFaulted || x.IsCanceled)
-					return new KeyValuePair<bool, T>(false, default(T));
+				{
+					Exception ex = x.Exception;
+					if (ex is AggregateException aex && aex.InnerExceptions.Count == 1)
+						ex = aex.InnerExceptions[0];
+
+					return ex switch
+					{
+						// Consume timeout exceptions
+						TimeoutException _ => new KeyValuePair<bool, T>(false, default(T)),
+						_ => throw ex,
+					};
+				}
 
 				return new KeyValuePair<bool, T>(true, x.Result);
 			});


### PR DESCRIPTION
Due to the tasks being configured with `.ContinueWith()` in the `TryReadAsync()` and `TryWriteAsync()` extension methods, potential exceptions were being silently consumed. The major problem was that the exceptions were not observed, which would lead to multiple warnings being emitted: 

```
A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. 
```

This PR: 
- Adds two tests that capture whether all exceptions have been observed
- Provides a fix that captures the exception and consumes it if it's a timeout exception (which is to be expected from calling a `Try*` method) or otherwise rethrows it so that the caller can be notified of the potential cause. 