### PR TITLE
Bugfix/try canceled without exception

### DIFF
--- a/src/CoCoL/ChannelExtensions.cs
+++ b/src/CoCoL/ChannelExtensions.cs
@@ -452,7 +452,7 @@ namespace CoCoL
 			}
 			else if (res.IsCanceled)
 			{
-				throw new OperationCanceledException();
+				throw new TaskCanceledException();
 			}
 		}
 
@@ -476,7 +476,7 @@ namespace CoCoL
 			}
 			else if (res.IsCanceled)
 			{
-				throw new OperationCanceledException();
+				throw new TaskCanceledException();
 			}
 		}
 
@@ -969,7 +969,7 @@ namespace CoCoL
 			}
 			else if (res.IsCanceled)
 			{
-				throw new OperationCanceledException();
+				throw new TaskCanceledException();
 			}
 		}
 

--- a/src/CoCoL/ChannelExtensions.cs
+++ b/src/CoCoL/ChannelExtensions.cs
@@ -314,7 +314,7 @@ namespace CoCoL
 						ex = aex.InnerExceptions[0];
 
 					// Check if it's the token that requested the cancellation
-					if (x.IsCanceled)
+					if (x.IsCanceled && cancelToken.IsCancellationRequested)
 						throw new TaskCanceledException();
 					// Otherwise, it's the timeout, which is caught by the null in the switch
 

--- a/src/UnitTest/ChannelExtensionsTest.cs
+++ b/src/UnitTest/ChannelExtensionsTest.cs
@@ -13,6 +13,10 @@ namespace UnitTest
         [TestInitialize]
         public void Setup()
         {
+            // Clean up any previous handlers
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+
             anyUnobservedExceptions = false;
             TaskScheduler.UnobservedTaskException += (s, e) =>
             {

--- a/src/UnitTest/TimeoutTests.cs
+++ b/src/UnitTest/TimeoutTests.cs
@@ -5,17 +5,42 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+#nullable enable
+
 namespace UnitTest
 {
 	[TestClass]
 	public class TimeoutTests
 	{
+		bool anyUnobservedExceptions = false;
+
+		[TestInitialize]
+		public void Setup()
+		{
+			// Clean up any previous handlers
+			anyUnobservedExceptions = false;
+			TaskScheduler.UnobservedTaskException += (s, e) =>
+			{
+				anyUnobservedExceptions = true;
+				e.SetObserved();
+			};
+		}
+
+		[TestCleanup]
+		public void Cleanup()
+		{
+			// Force finalizers to run
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+			Assert.IsFalse(anyUnobservedExceptions, "Unobserved exception should have been caught.");
+		}
+
 		[TestMethod]
 		public void TestTimeoutSimple()
 		{
 			var c = ChannelManager.CreateChannel<int>();
 
-			Func<Task> p = async () =>
+			async Task p()
 			{
 				try
 				{
@@ -25,7 +50,7 @@ namespace UnitTest
 				catch (TimeoutException)
 				{
 				}
-			};
+			}
 
 			var t = p();
 			if (!t.Wait(TimeSpan.FromSeconds(3)))
@@ -39,129 +64,154 @@ namespace UnitTest
 			var c2 = ChannelManager.CreateChannel<int>();
 			var c3 = ChannelManager.CreateChannel<int>();
 
-			Func<Task> p = async () =>
+			async Task p()
+			{
+				try
 				{
-					try
-					{
-						await MultiChannelAccess.ReadFromAnyAsync(TimeSpan.FromSeconds(2), c1, c2, c3);
-						throw new UnittestException("Timeout did not happen?");
-					}
-					catch (TimeoutException)
-					{
-					}
-				};
+					await MultiChannelAccess.ReadFromAnyAsync(TimeSpan.FromSeconds(2), c1, c2, c3);
+					throw new UnittestException("Timeout did not happen?");
+				}
+				catch (TimeoutException)
+				{
+				}
+			}
 
 			var t = p();
 			if (!t.Wait(TimeSpan.FromSeconds(3)))
 				throw new UnittestException("Failed to get timeout");
-
 		}
 
 		[TestMethod]
-		public void TestTimeoutMultipleTimes()
+		public async Task TestTimeoutMultipleTimes()
 		{
 			var c1 = ChannelManager.CreateChannel<int>();
 			var c2 = ChannelManager.CreateChannel<int>();
 			var c3 = ChannelManager.CreateChannel<int>();
 			var c4 = ChannelManager.CreateChannel<int>();
+			Task? r1 = null, r2 = null, r3 = null, r4 = null;
 
-			Func<Task> p = async () =>
+			async Task ObservePotentialExceptions()
+			{
+				// Observe the exceptions on the other tasks
+				if (r1 != null) try { await r1; } catch { }
+				if (r2 != null) try { await r2; } catch { }
+				if (r3 != null) try { await r3; } catch { }
+				if (r4 != null) try { await r4; } catch { }
+			}
+
+			async Task p()
+			{
+				r1 = c1.ReadAsync(TimeSpan.FromSeconds(5));
+				r2 = c2.ReadAsync(TimeSpan.FromSeconds(4));
+				r3 = c3.ReadAsync(TimeSpan.FromSeconds(2));
+				r4 = c4.ReadAsync(TimeSpan.FromSeconds(4));
+				try
 				{
-					try
-					{
-						var t = await Task.WhenAny(
-							c1.ReadAsync(TimeSpan.FromSeconds(5)),
-							c2.ReadAsync(TimeSpan.FromSeconds(4)),
-							c3.ReadAsync(TimeSpan.FromSeconds(2)),
-							c4.ReadAsync(TimeSpan.FromSeconds(4))
-						);
+					var t = await Task.WhenAny(
+						r1, r2, r3, r4
+					);
 
-						if (!t.IsFaulted || !(t.Exception.InnerException is TimeoutException))
-							throw new UnittestException("Timeout did not happen?");
-					}
-					catch (TimeoutException)
-					{
-					}
-				};
+					if (!t.IsFaulted || t.Exception.InnerException is not TimeoutException)
+						throw new UnittestException("Timeout did not happen?");
+				}
+				catch (TimeoutException)
+				{
+				}
+			}
 
 			if (!p().Wait(TimeSpan.FromSeconds(3)))
 				throw new UnittestException("Failed to get timeout");
+			await ObservePotentialExceptions();
 
 			if (!p().Wait(TimeSpan.FromSeconds(3)))
 				throw new UnittestException("Failed to get timeout");
+			await ObservePotentialExceptions();
 
 		}
 
 		[TestMethod]
-		public void TestTimeoutMultipleTimesSuccession()
+		public async Task TestTimeoutMultipleTimesSuccession()
 		{
 			var c1 = ChannelManager.CreateChannel<int>();
 			var c2 = ChannelManager.CreateChannel<int>();
 			var c3 = ChannelManager.CreateChannel<int>();
 			var c4 = ChannelManager.CreateChannel<int>();
+			Task? r1 = null, r2 = null, r3 = null, r4 = null;
 
-			Func<Task> p = async () =>
+			async Task ObservePotentialExceptions()
+			{
+				// Observe the exceptions on the other tasks
+				if (r1 != null) try { await r1; } catch { }
+				if (r2 != null) try { await r2; } catch { }
+				if (r3 != null) try { await r3; } catch { }
+				if (r4 != null) try { await r4; } catch { }
+			}
+
+			async Task p()
+			{
+				r1 = c1.ReadAsync(TimeSpan.FromSeconds(7));
+				r2 = c2.ReadAsync(TimeSpan.FromSeconds(3));
+				r3 = c3.ReadAsync(TimeSpan.FromSeconds(2));
+				r4 = c4.ReadAsync(TimeSpan.FromSeconds(7));
+				try
 				{
-					try
+					var tasks = new List<Task> { r1, r2, r3, r4 };
+
+					//Console.WriteLine("Waiting for c3");
+					var t = await Task.WhenAny(tasks);
+					//Console.WriteLine("Not waiting for c3");
+
+					if (!t.IsFaulted || t.Exception.InnerException is not TimeoutException)
+						throw new UnittestException("Timeout did not happen on c3?");
+
+					if (!tasks[2].IsFaulted || tasks[2].Exception?.InnerException is not TimeoutException)
 					{
-						var tasks = new List<Task>(new[] {
-							c1.ReadAsync(TimeSpan.FromSeconds(7)),
-							c2.ReadAsync(TimeSpan.FromSeconds(3)),
-							c3.ReadAsync(TimeSpan.FromSeconds(2)),
-							c4.ReadAsync(TimeSpan.FromSeconds(7))
-						});
+						for (var i = 0; i < tasks.Count; i++)
+							if (tasks[i].IsFaulted && i != 2)
+								throw new UnittestException(string.Format("Timeout happened on c{0}, but should have happened on c3?", i + 1));
 
-						//Console.WriteLine("Waiting for c3");
-						var t = await Task.WhenAny(tasks);
-						//Console.WriteLine("Not waiting for c3");
-
-						if (!t.IsFaulted || !(t.Exception.InnerException is TimeoutException))
-							throw new UnittestException("Timeout did not happen on c3?");
-
-						if (!tasks[2].IsFaulted || !(tasks[2].Exception.InnerException is TimeoutException))
-						{
-							for (var i = 0; i < tasks.Count; i++)
-								if (tasks[i].IsFaulted && i != 2)
-									throw new UnittestException(string.Format("Timeout happened on c{0}, but should have happened on c3?", i + 1));
-
-							throw new UnittestException("Timeout happened on another channel than c3?");
-						}
-
-						tasks.RemoveAt(2);
-
-						if (tasks.Any(x => x.IsFaulted))
-							throw new UnittestException("Unexpected task fault?");
-
-						//Console.WriteLine("Waiting for c2");
-						t = await Task.WhenAny(tasks);
-						//Console.WriteLine("Not waiting for c2");
-
-						if (!t.IsFaulted || !(t.Exception.InnerException is TimeoutException))
-							throw new UnittestException("Timeout did not happen for c2?");
-
-						if (!tasks[1].IsFaulted || !(tasks[1].Exception.InnerException is TimeoutException))
-						{
-							for (var i = 0; i < tasks.Count; i++)
-								if (tasks[i].IsFaulted && i != 1)
-									throw new UnittestException(string.Format("Timeout happened on c{0}, but should have happened on c2?", i + 1));
-							throw new UnittestException("Timeout happened on another channel than c2?");
-						}
-
-						tasks.RemoveAt(1);
-
-						if (tasks.Any(x => x.IsFaulted))
-							throw new UnittestException("Unexpected task fault?");
-
-						//Console.WriteLine("Completed");
+						throw new UnittestException("Timeout happened on another channel than c3?");
 					}
-					catch (TimeoutException)
+
+					tasks.RemoveAt(2);
+
+					if (tasks.Any(x => x.IsFaulted))
+						throw new UnittestException("Unexpected task fault?");
+
+					//Console.WriteLine("Waiting for c2");
+					t = await Task.WhenAny(tasks);
+					//Console.WriteLine("Not waiting for c2");
+
+					if (!t.IsFaulted || t.Exception.InnerException is not TimeoutException)
+						throw new UnittestException("Timeout did not happen for c2?");
+
+					if (!tasks[1].IsFaulted || tasks[1].Exception?.InnerException is not TimeoutException)
 					{
+						for (var i = 0; i < tasks.Count; i++)
+							if (tasks[i].IsFaulted && i != 1)
+								throw new UnittestException(string.Format("Timeout happened on c{0}, but should have happened on c2?", i + 1));
+						throw new UnittestException("Timeout happened on another channel than c2?");
 					}
-				};
+
+					tasks.RemoveAt(1);
+
+					if (tasks.Any(x => x.IsFaulted))
+						throw new UnittestException("Unexpected task fault?");
+
+					//Console.WriteLine("Completed");
+				}
+				catch (TimeoutException)
+				{
+				}
+			}
 
 			for (var i = 0; i < 5; i++)
+			{
 				if (!p().Wait(TimeSpan.FromSeconds(4)))
 					throw new UnittestException("Failed to get timeout");
+				// Observe the exceptions on the other tasks
+				await ObservePotentialExceptions();
+			}
 		}
 
 		[TestMethod]
@@ -169,51 +219,51 @@ namespace UnitTest
 		{
 			var c = ChannelManager.CreateChannel<int>();
 
-			Func<Task> p = async () =>
+			async Task p()
+			{
+				try
 				{
-					try
-					{
-						var tasks = new List<Task>(new[] {
+					var tasks = new List<Task> {
 							c.ReadAsync(),
 							c.ReadAsync(TimeSpan.FromSeconds(1)),
 							c.ReadAsync(TimeSpan.FromSeconds(2))
-						});
+						};
 
-						var t = await Task.WhenAny(tasks);
+					var t = await Task.WhenAny(tasks);
 
-						if (!t.IsFaulted || !(t.Exception.InnerException is TimeoutException))
-							throw new UnittestException("Timeout did not happen on op2?");
+					if (!t.IsFaulted || t.Exception.InnerException is not TimeoutException)
+						throw new UnittestException("Timeout did not happen on op2?");
 
-						if (!tasks[1].IsFaulted || !(tasks[1].Exception.InnerException is TimeoutException))
-						{
-							for (var i = 0; i < tasks.Count; i++)
-								if (tasks[i].IsFaulted && i != 1)
-									throw new UnittestException(string.Format("Timeout happened on op{0}, but should have happened on op2?", i + 1));
-
-							throw new UnittestException("Timeout happened on another channel than op2?");
-						}
-
-						tasks.RemoveAt(1);
-
-						t = await Task.WhenAny(tasks);
-
-						if (!t.IsFaulted || !(t.Exception.InnerException is TimeoutException))
-							throw new UnittestException("Timeout did not happen on op2?");
-
-						if (!tasks[1].IsFaulted || !(tasks[1].Exception.InnerException is TimeoutException))
-						{
-							for (var i = 0; i < tasks.Count; i++)
-								if (tasks[i].IsFaulted && i != 1)
-									throw new UnittestException(string.Format("Timeout happened on op{0}, but should have happened on op3?", i + 1));
-
-							throw new UnittestException("Timeout happened on another channel than op3?");
-						}
-
-					}
-					catch (TimeoutException)
+					if (!tasks[1].IsFaulted || tasks[1].Exception?.InnerException is not TimeoutException)
 					{
+						for (var i = 0; i < tasks.Count; i++)
+							if (tasks[i].IsFaulted && i != 1)
+								throw new UnittestException(string.Format("Timeout happened on op{0}, but should have happened on op2?", i + 1));
+
+						throw new UnittestException("Timeout happened on another channel than op2?");
 					}
-				};
+
+					tasks.RemoveAt(1);
+
+					t = await Task.WhenAny(tasks);
+
+					if (!t.IsFaulted || !(t.Exception.InnerException is TimeoutException))
+						throw new UnittestException("Timeout did not happen on op2?");
+
+					if (!tasks[1].IsFaulted || tasks[1].Exception?.InnerException is not TimeoutException)
+					{
+						for (var i = 0; i < tasks.Count; i++)
+							if (tasks[i].IsFaulted && i != 1)
+								throw new UnittestException(string.Format("Timeout happened on op{0}, but should have happened on op3?", i + 1));
+
+						throw new UnittestException("Timeout happened on another channel than op3?");
+					}
+
+				}
+				catch (TimeoutException)
+				{
+				}
+			}
 
 			for (var i = 0; i < 5; i++)
 				if (!p().Wait(TimeSpan.FromSeconds(3)))
@@ -221,49 +271,61 @@ namespace UnitTest
 		}
 
 		[TestMethod]
-		public void TestTimeoutWithBuffers()
+		public async Task TestTimeoutWithBuffers()
 		{
 			var c = ChannelManager.CreateChannel<int>(buffersize: 1);
+			Task? w1 = null, w2 = null, w3 = null;
 
-			Func<Task> p = async () =>
+			async Task ObservePotentialExceptions()
+			{
+				// Observe the exceptions on the other tasks
+				// w1 is the buffered write,
+				//if (w1 != null) try { await w1; } catch { }
+				if (w2 != null) try { await w2; } catch { }
+				if (w3 != null) try { await w3; } catch { }
+			}
+
+			async Task p()
+			{
+				try
 				{
-					try
+					w1 = c.WriteAsync(4);
+					w2 = c.WriteAsync(5, TimeSpan.FromSeconds(1));
+					w3 = c.WriteAsync(6, TimeSpan.FromSeconds(2));
+					var tasks = new List<Task> { w1, w2, w3 };
+
+					var t = await Task.WhenAny(tasks);
+
+					if (!t.IsCompleted)
+						throw new UnittestException("Buffered write failed?");
+
+					tasks.RemoveAt(0);
+
+					t = await Task.WhenAny(tasks);
+
+					if (!t.IsFaulted || t.Exception.InnerException is not TimeoutException)
+						throw new UnittestException("Timeout did not happen on op1?");
+
+					if (!tasks[0].IsFaulted || tasks[0].Exception?.InnerException is not TimeoutException)
 					{
-						var tasks = new List<Task>(new[] {
-							c.WriteAsync(4),
-							c.WriteAsync(5, TimeSpan.FromSeconds(1)),
-							c.WriteAsync(6, TimeSpan.FromSeconds(2))
-						});
+						for (var i = 0; i < tasks.Count; i++)
+							if (tasks[i].IsFaulted && i != 0)
+								throw new UnittestException(string.Format("Timeout happened on op{0}, but should have happened on op1?", i + 1));
 
-						var t = await Task.WhenAny(tasks);
-
-						if (!t.IsCompleted)
-							throw new UnittestException("Buffered write failed?");
-
-						tasks.RemoveAt(0);
-
-						t = await Task.WhenAny(tasks);
-
-						if (!t.IsFaulted || !(t.Exception.InnerException is TimeoutException))
-							throw new UnittestException("Timeout did not happen on op1?");
-
-						if (!tasks[0].IsFaulted || !(tasks[0].Exception.InnerException is TimeoutException))
-						{
-							for (var i = 0; i < tasks.Count; i++)
-								if (tasks[i].IsFaulted && i != 0)
-									throw new UnittestException(string.Format("Timeout happened on op{0}, but should have happened on op1?", i + 1));
-
-							throw new UnittestException("Timeout happened on another channel than op1?");
-						}
+						throw new UnittestException("Timeout happened on another channel than op1?");
 					}
-					catch (TimeoutException)
-					{
-					}
-				};
+				}
+				catch (TimeoutException)
+				{
+				}
+			}
 
 			for (var i = 0; i < 5; i++)
+			{
 				if (!p().Wait(TimeSpan.FromSeconds(3)))
 					throw new UnittestException("Failed to get timeout");
+				await ObservePotentialExceptions();
+			}
 
 		}
 	}

--- a/src/UnitTest/TimeoutTests.cs
+++ b/src/UnitTest/TimeoutTests.cs
@@ -17,6 +17,10 @@ namespace UnitTest
 		[TestInitialize]
 		public void Setup()
 		{
+			// Force finalizers to run
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+
 			// Clean up any previous handlers
 			anyUnobservedExceptions = false;
 			TaskScheduler.UnobservedTaskException += (s, e) =>


### PR DESCRIPTION
The fix in #21 didn't cover all cases: a task (i.e. the `Try*Async` methods) could be in a state where it's canceled without having an exception. This meant that the rethrow logic was incorrect, as you cannot throw null. To fix this: 

- If the task has been canceled, but it isn't by the potentially cancellation token parameter, then it must have been internally that the timeout has been consumed in turn cancelling the task. 
- If the cancellation token has been cancelled, then an exception will be thrown, as the caller would expect this. 
- Otherwise, if any other exception ocurred, then it will be rethrown. 

The different extension methods for the `Try*Async` methods have also been changed to call the same "main" version accepting both a timeout and a cancellation token, to ensure that they all use the same logic. 